### PR TITLE
add minor fix to domain migration for certificate update

### DIFF
--- a/poppy/manager/default/services.py
+++ b/poppy/manager/default/services.py
@@ -768,7 +768,7 @@ class DefaultServicesController(base.ServicesController):
                 cert_details[provider]['extra_info']['status'] = cert_status
                 cert_details[provider] = json.dumps(cert_details[provider])
 
-                storage_controller.update_cert_info(
+                storage_controller.update_certificate(
                     cert_obj.domain_name,
                     cert_obj.cert_type,
                     cert_obj.flavor_id,

--- a/tests/unit/manager/default/test_services.py
+++ b/tests/unit/manager/default/test_services.py
@@ -1369,7 +1369,7 @@ class DefaultManagerServiceTests(base.TestCase):
         )
 
         self.mock_storage.services_controller.\
-            update_cert_info.assert_called_once_with(
+            update_certificate.assert_called_once_with(
                 "domain.com",
                 "san",
                 "flavor_id",
@@ -1445,7 +1445,7 @@ class DefaultManagerServiceTests(base.TestCase):
         )
 
         self.mock_storage.services_controller.\
-            update_cert_info.assert_called_once_with(
+            update_certificate.assert_called_once_with(
                 "new-domain.com",
                 "san",
                 "flavor_id",
@@ -1520,7 +1520,7 @@ class DefaultManagerServiceTests(base.TestCase):
         )
 
         self.mock_storage.services_controller.\
-            update_cert_info.assert_called_once_with(
+            update_certificate.assert_called_once_with(
                 "domain.com",
                 "san",
                 "flavor_id",
@@ -1583,7 +1583,7 @@ class DefaultManagerServiceTests(base.TestCase):
         )
 
         self.assertFalse(
-            self.mock_storage.services_controller.update_cert_info.called
+            self.mock_storage.services_controller.update_certificate.called
         )
 
         (
@@ -1617,7 +1617,7 @@ class DefaultManagerServiceTests(base.TestCase):
             )
 
         self.assertFalse(
-            self.mock_storage.services_controller.update_cert_info.called
+            self.mock_storage.services_controller.update_certificate.called
         )
 
         self.assertFalse(


### PR DESCRIPTION
JIRA: CDN-1089
Changed update_cert_info which did not have a definition to update_certificate for domain migration.