### PR TITLE
Add fix for change url for sni cert creation

### DIFF
--- a/poppy/provider/akamai/certificates.py
+++ b/poppy/provider/akamai/certificates.py
@@ -445,9 +445,7 @@ class CertificateController(base.CertificateBase):
                         continue
 
                     # adding sans should get them cloned into sni host names
-                    resp_json['csr']['sans'] = resp_json['csr']['sans'].append(
-                        cert_obj.domain_name
-                    )
+                    resp_json['csr']['sans'].append(cert_obj.domain_name)
 
                     # PUT the enrollment including the modifications
                     headers = {


### PR DESCRIPTION
[CDN-1102](https://jira.rax.io/browse/CDN-1102)

The sni cert creation was not working due to a bug, where the change URL wasn't being generated.
The fix has been added in this commit.