### PR TITLE
[CDN-1175] Add fix to remove SNI domain from certificate using patch

### DIFF
--- a/poppy/distributed_task/taskflow/task/delete_service_tasks.py
+++ b/poppy/distributed_task/taskflow/task/delete_service_tasks.py
@@ -230,6 +230,8 @@ class DeleteCertificatesForService(task.Task):
             service_id
         )
 
+        storage_cert_obj = service_controller.ssl_certificate_storage
+
         kwargs = {
             'project_id': project_id,
             'context_dict': context_utils.get_current().to_dict(),
@@ -244,6 +246,11 @@ class DeleteCertificatesForService(task.Task):
             ):
                 kwargs["domain_name"] = domain.domain
                 kwargs["cert_type"] = domain.certificate
+                kwargs["cert_details"] = storage_cert_obj.get_certs_by_domain(
+                    domain.domain,
+                    cert_type=domain.certificate
+                ).cert_details
+
                 LOG.info(
                     "Delete service submit task {0} cert delete "
                     "domain {1}.".format(

--- a/poppy/distributed_task/taskflow/task/delete_ssl_certificate_tasks.py
+++ b/poppy/distributed_task/taskflow/task/delete_ssl_certificate_tasks.py
@@ -30,11 +30,12 @@ class DeleteProviderSSLCertificateTask(task.Task):
     default_provides = "responders"
 
     def execute(self, providers_list, domain_name, cert_type,
-                project_id, flavor_id):
+                project_id, flavor_id, cert_details):
         service_controller = memoized_controllers.task_controllers('poppy')
 
         cert_obj = ssl_certificate.SSLCertificate(flavor_id, domain_name,
-                                                  cert_type, project_id)
+                                                  cert_type, project_id,
+                                                  cert_details)
 
         responders = []
         # try to delete all certificates from each provider
@@ -44,7 +45,7 @@ class DeleteProviderSSLCertificateTask(task.Task):
                     cert_obj.to_dict(), provider))
             responder = service_controller.provider_wrapper.delete_certificate(
                 service_controller._driver.providers[provider.lower()],
-                cert_obj,
+                cert_obj
             )
             responders.append(responder)
 

--- a/poppy/distributed_task/taskflow/task/delete_ssl_certificate_tasks.py
+++ b/poppy/distributed_task/taskflow/task/delete_ssl_certificate_tasks.py
@@ -12,6 +12,7 @@
 # implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import json
 
 from oslo_config import cfg
 from oslo_log import log
@@ -29,9 +30,15 @@ conf(project='poppy', prog='poppy', args=[])
 class DeleteProviderSSLCertificateTask(task.Task):
     default_provides = "responders"
 
-    def execute(self, providers_list, domain_name, cert_type,
-                project_id, flavor_id, cert_details):
+    def execute(self, providers_list_json, domain_name, cert_type,
+                project_id, cert_obj_json):
         service_controller = memoized_controllers.task_controllers('poppy')
+
+        cert_obj_json = json.loads(cert_obj_json)
+        providers_list = json.loads(providers_list_json)
+
+        flavor_id = cert_obj_json['flavor_id']
+        cert_details = cert_obj_json['cert_details']
 
         cert_obj = ssl_certificate.SSLCertificate(flavor_id, domain_name,
                                                   cert_type, project_id,

--- a/poppy/transport/pecan/controllers/v1/ssl_certificates.py
+++ b/poppy/transport/pecan/controllers/v1/ssl_certificates.py
@@ -72,14 +72,21 @@ class SSLCertificateController(base.Controller, hooks.HookController):
             helpers.abort_with_message)
     )
     def delete(self, domain_name):
-        # For now we only support 'san' cert type
-        cert_type = pecan.request.GET.get('cert_type', 'san')
 
         certificate_controller = \
             self._driver.manager.ssl_certificate_controller
+
+        certificate_info_dict = json.loads(pecan.request.body.decode('utf-8'))
+
         try:
+            project_id = certificate_info_dict.get('project_id')
+            certs_info = certificate_controller.get_certs_info_by_domain(
+                domain_name, project_id)
+
+            cert_type = certs_info.cert_type
+
             certificate_controller.delete_ssl_certificate(
-                self.project_id, domain_name, cert_type
+                project_id, domain_name, cert_type
             )
         except ValueError as e:
             pecan.abort(400, detail='Delete ssl certificate failed. '

--- a/tests/unit/distributed_task/taskflow/test_flows.py
+++ b/tests/unit/distributed_task/taskflow/test_flows.py
@@ -1054,6 +1054,17 @@ class TestFlowRuns(base.TestCase):
 
     def test_delete_ssl_certificate_normal(self):
         providers = ['cdn_provider']
+        cert_details = {
+            "Akamai": {
+                "cert_domain": "secured.sni.altcdn.com",
+                "extra_info": {
+                    "status": "create_in_progress",
+                    "change_url": "/cps/v2/enrollments/12345/changes/3159",
+                    "created_at": "2018-05-02 16:11:55.671460",
+                    "sni_cert": "secured.sni.altcdn.com"
+                }
+            }
+        }
         cert_obj = ssl_certificate.SSLCertificate(
             'cdn',
             'mytestsite.com',
@@ -1066,7 +1077,8 @@ class TestFlowRuns(base.TestCase):
             'cert_obj': json.dumps(cert_obj.to_dict()),
             'providers_list': json.dumps(providers),
             'flavor_id': "premium",
-            'context_dict': context_utils.RequestContext().to_dict()
+            'context_dict': context_utils.RequestContext().to_dict(),
+            'cert_details': cert_details
         }
 
         (

--- a/tests/unit/distributed_task/taskflow/test_flows.py
+++ b/tests/unit/distributed_task/taskflow/test_flows.py
@@ -1074,8 +1074,8 @@ class TestFlowRuns(base.TestCase):
             'cert_type': "san",
             'project_id': json.dumps(str(uuid.uuid4())),
             'domain_name': "mytestsite.com",
-            'cert_obj': json.dumps(cert_obj.to_dict()),
-            'providers_list': json.dumps(providers),
+            'cert_obj_json': json.dumps(cert_obj.to_dict()),
+            'providers_list_json': json.dumps(providers),
             'flavor_id': "premium",
             'context_dict': context_utils.RequestContext().to_dict(),
             'cert_details': cert_details

--- a/tests/unit/distributed_task/taskflow/test_flows.py
+++ b/tests/unit/distributed_task/taskflow/test_flows.py
@@ -549,6 +549,9 @@ class TestFlowRuns(base.TestCase):
             service_mock = mock.Mock()
             type(service_mock).domains = []
             storage_controller.get_service.return_value = service_mock
+            storage_controller.get_service.return_value.provider_details = {
+                'akamai': []
+            }
             dns_controller.delete = mock.Mock()
             dns_controller.delete._mock_return_value = {
                 'cdn_provider': {


### PR DESCRIPTION
[CDN-1175](https://jira.rax.io/browse/CDN-1175)
Add changes for removal of domain from certificate using patch
[CDN-1153](https://jira.rax.io/browse/CDN-1153)
[CDN-1176](https://jira.rax.io/browse/CDN-1176)
Normalize all the code that affects CDN-1153, CDN-1175, CDN-1176 as they all use delete_certificate task.