### PR TITLE
Pin cassandra driver to 3.8.0

### DIFF
--- a/requirements/storage/cassandra.txt
+++ b/requirements/storage/cassandra.txt
@@ -1,2 +1,2 @@
-cassandra-driver>=3.0.0
+cassandra-driver==3.8.0
 cdeploy


### PR DESCRIPTION
Newer versions seem to have issues maintaining
connections to the cassandra host and throw:
ConnectionException("Pool is shutdown").

For now, we'll pin to a known working version and
investigate subsequent driver releases.