### PR TITLE
[CDN-931] Fix timeout in poppy health api

### DIFF
--- a/poppy/provider/akamai/driver.py
+++ b/poppy/provider/akamai/driver.py
@@ -243,6 +243,7 @@ class CDNProvider(base.Driver):
         unique_id = str(uuid.uuid4())
         request_headers = {
             'Content-type': 'application/json',
+            'X-Customer-Id': "000",
             'Accept': 'text/plain'
         }
 


### PR DESCRIPTION
Akamai now requires the header: 'X-Customer-Id' to be
set.