### PR TITLE
Update docker-compose config to version 2

### DIFF
--- a/docker/compose/dependencies.yml
+++ b/docker/compose/dependencies.yml
@@ -1,15 +1,17 @@
-zookeeper:
+version: '2'
+services:
+  zookeeper:
     image: jplock/zookeeper
     ports:
-     - 2181:2181
+      - 2181:2181
 
-cassandra:
+  cassandra:
     image: library/cassandra
     ports:
-     - 9160:9160
-     - 9042:9042
+      - 9160:9160
+      - 9042:9042
 
-mimic:
+  mimic:
     image: amitgandhinz/mimic
     ports:
-     - 8900:8900
+      - 8900:8900


### PR DESCRIPTION
This update (version 2+) allows us to take advantage of named volumes and
networks (which could, for example, be shared with a
front-end control panel).