### PR TITLE
[CDN-1243] Ensure retry is working for delete domains.

### DIFF
--- a/poppy/distributed_task/taskflow/flow/delete_ssl_certificate.py
+++ b/poppy/distributed_task/taskflow/flow/delete_ssl_certificate.py
@@ -16,7 +16,6 @@
 from oslo_config import cfg
 from oslo_log import log
 
-from taskflow.patterns import graph_flow
 from taskflow.patterns import linear_flow
 from taskflow import retry
 
@@ -31,7 +30,7 @@ conf(project='poppy', prog='poppy', args=[])
 
 
 def delete_ssl_certificate():
-    flow = graph_flow.Flow('Deleting poppy ssl certificate').add(
+    flow = linear_flow.Flow('Deleting poppy ssl certificate').add(
         linear_flow.Flow('Update Oslo Context').add(
             common.ContextUpdateTask()),
         linear_flow.Flow("Deleting poppy ssl certificate",

--- a/poppy/distributed_task/taskflow/task/delete_ssl_certificate_tasks.py
+++ b/poppy/distributed_task/taskflow/task/delete_ssl_certificate_tasks.py
@@ -25,7 +25,6 @@ LOG = log.getLogger(__name__)
 conf = cfg.CONF
 conf(project='poppy', prog='poppy', args=[])
 
-
 class DeleteProviderSSLCertificateTask(task.Task):
     default_provides = "responders"
 
@@ -51,10 +50,18 @@ class DeleteProviderSSLCertificateTask(task.Task):
                 service_controller._driver.providers[provider.lower()],
                 cert_obj,
             )
+
+            if responder:
+                if 'error' in responder[provider]:
+                    msg = "Failed to delete ssl certificate: {0} : due to {1}:" \
+                          "The delete operation will be retried".format(
+                        cert_obj.to_dict(), responder[provider]['error'])
+                    LOG.info(msg)
+                    raise Exception(msg)
+
             responders.append(responder)
 
         return responders
-
 
 class SendNotificationTask(task.Task):
 

--- a/tests/unit/distributed_task/taskflow/test_flows.py
+++ b/tests/unit/distributed_task/taskflow/test_flows.py
@@ -208,6 +208,32 @@ class TestFlowRuns(base.TestCase):
         common.create_log_delivery_container = mock.Mock()
 
     @staticmethod
+    def patch_delete_ssl_certificate_retry_flow(
+            service_controller,
+            storage_controller,
+            dns_controller,
+            ssl_cert_controller
+    ):
+        storage_controller.get = mock.Mock()
+        storage_controller.update = mock.Mock()
+        ssl_cert_controller.storage.delete_certificate = mock.Mock()
+        storage_controller._driver.close_connection = mock.Mock()
+        service_controller.provider_wrapper.delete_certificate = mock.Mock()
+        service_controller.provider_wrapper.delete_certificate. \
+            _mock_return_value = {
+            "cdn_provider": {
+                'error': "",
+                'error_detail': ""
+            }
+        }
+        service_controller._driver = mock.Mock()
+        service_controller._driver.providers.__getitem__ = mock.Mock()
+        service_controller._driver.notification = [mock.Mock()]
+        dns_controller.create = mock.Mock()
+        dns_controller.create._mock_return_value = []
+        common.create_log_delivery_container = mock.Mock()
+
+    @staticmethod
     def patch_recreate_ssl_certificate_flow(
             service_controller, storage_controller, dns_controller):
         storage_controller.get = mock.Mock()
@@ -1092,3 +1118,58 @@ class TestFlowRuns(base.TestCase):
                 delete_ssl_certificate.delete_ssl_certificate(),
                 store=kwargs
             )
+
+    def test_delete_ssl_certificate_retry(self):
+        """Test the retry functionality.
+
+        Test that when ``delete_ssl_certificate()`` fails,
+        It is retried as per the configuration.
+
+        Check that number of times the method
+        ``delete_ssl_certificate()`` is called is equal
+        to retry count as per the configuration.
+        """
+        providers = ['cdn_provider']
+        cert_obj = ssl_certificate.SSLCertificate(
+            'cdn',
+            'www.domain.com',
+            'sni',
+        )
+        kwargs = {
+            'cert_type': "sni",
+            'project_id': "123",
+            'domain_name': "www.domain.com",
+            'cert_obj': json.dumps(cert_obj.to_dict()),
+            'providers_list': providers,
+            'flavor_id': "cdn",
+            'context_dict': context_utils.RequestContext().to_dict()
+        }
+
+        (
+            service_controller,
+            storage_controller,
+            dns_controller,
+            ssl_cert_controller
+        ) = self.all_controllers()
+
+        with MonkeyPatchControllers(service_controller,
+                                    dns_controller,
+                                    storage_controller,
+                                    ssl_cert_controller,
+                                    memoized_controllers.task_controllers):
+            self.patch_delete_ssl_certificate_retry_flow(
+                service_controller,
+                storage_controller,
+                dns_controller,
+                ssl_cert_controller
+            )
+
+            self.assertRaises(Exception,
+                              engines.run,
+                              delete_ssl_certificate.delete_ssl_certificate(),
+                              store=kwargs)
+
+            # Check that the delete_certificate() has been called
+            # Five times(which is the retry count).
+            self.assertEqual(service_controller.provider_wrapper. \
+                             delete_certificate.call_count, 5)


### PR DESCRIPTION
When a request for delete domain from poppy service arrives and if the
delete operation fails due to pending changes on the certificate or
an error from cps side or any other valid errors; The whole delete
operation for that domain should be retried later.