### PR TITLE
Add poppy.conf option improving the sni 'upsert' process

### DIFF
--- a/poppy/provider/akamai/driver.py
+++ b/poppy/provider/akamai/driver.py
@@ -136,6 +136,8 @@ AKAMAI_OPTIONS = [
 
     cfg.ListOpt('sni_cert_cnames',
                 help='A list of sni certs cname host names'),
+    cfg.ListOpt('sni_cert_enrollment_ids',
+                help='Optional list of enrollmentIds. One for each item in "sni_cert_cname"'),
     # SANCERT related configs
     cfg.ListOpt('san_cert_cnames',
                 help='A list of san certs cname host names'),


### PR DESCRIPTION
Added an optional setting in poppy.conf (sni_cert_enrollment_ids).
This is intended to be used with the upsert_sni_cert_info script
to speed up the input process.

The value should be Should be ordered the same as the
'sni_cert_cnames' setting (and have the same number of elements).

---------------------------
Example config (poppy.conf):

sni_cert_cnames = sec1.sni.cdn.com, sec1.sni.cdn.com
sni_cert_enrollment_ids = 11100, 11101