### PR TITLE
[CDN-1175] Pass correct args to delete_ssl_certificate flow.

### DIFF
--- a/poppy/distributed_task/taskflow/task/update_service_tasks.py
+++ b/poppy/distributed_task/taskflow/task/update_service_tasks.py
@@ -386,7 +386,9 @@ class DeleteCertsForRemovedDomains(task.Task):
         kwargs = {
             'project_id': project_id,
             'cert_type': 'san',
-            'context_dict': context_utils.get_current().to_dict()
+            'context_dict': context_utils.get_current().to_dict(),
+            'flavor_id': service_new.flavor_id,
+            'providers_list': service_new.provider_details.keys()
         }
 
         for domain in removed_domains:


### PR DESCRIPTION
When a domain from poppy service is deleted, update_service flow
will be invoked. This flow in turn calls delete_ssl_certificate
flow but does not pass required arguments flavor_id and
providers_list. This causes delete_ssl_certificate flow to fail.
Fixing this to supply the correct arguments to the flow.