### PR TITLE
Fix failing old functional test cases.

### DIFF
--- a/poppy/storage/mockdb/certificates.py
+++ b/poppy/storage/mockdb/certificates.py
@@ -77,4 +77,5 @@ class CertificatesController(base.CertificatesController):
             if len(certs) == 1:
                 return certs[0]
             else:
-                return certs
+                raise ValueError("No matching certificates found for "
+                                 "the domain {}".format(domain_name))

--- a/tests/functional/transport/pecan/base.py
+++ b/tests/functional/transport/pecan/base.py
@@ -61,6 +61,8 @@ class BaseFunctionalTest(base.TestCase):
 
             mock_cert_info = mock.MagicMock()
             mock_cert_info.get_cert_config.return_value = {}
+            mock_cert_info.get_san_cert_hostname_limit.return_value = 0
+            mock_cert_info.update_cert_config.return_value = {}
 
             mod_san_q = mock.MagicMock()
             mod_san_q.traverse_queue.return_value = []

--- a/tests/functional/transport/pecan/controllers/test_set_service_status.py
+++ b/tests/functional/transport/pecan/controllers/test_set_service_status.py
@@ -152,11 +152,12 @@ class TestServicesState(base.FunctionalTest):
 
         self.assertEqual(response.status_code, 400)
 
-    @given(strategies.text(min_size=257))
-    def test_services_state_invalid_project_id(self, project_id):
+    def test_services_state_invalid_project_id(self):
         # NOTE(TheSriram): the min size is assigned to 257, since
         # project_id regex allows up to 256 chars
         # invalid project_id field
+        project_id = '_'.join([str(uuid.uuid4()) for i in range(7)])
+        self.assertTrue(len(project_id) > 256)
         self.req_body['project_id'] = project_id
         self.req_body['status'] = 'deployed'
         response = self.app.post(


### PR DESCRIPTION
Some of the Functional test cases are failing while trying to
serialize a mock object.
This code changes should be fixing them.