### PR TITLE
Fix failing Flake8 tests

### DIFF
--- a/poppy/distributed_task/taskflow/driver.py
+++ b/poppy/distributed_task/taskflow/driver.py
@@ -64,7 +64,7 @@ class TaskFlowDistributedTaskDriver(base.Driver):
             # This topic could become more complicated
             "board": self.distributed_task_conf.jobboard_backend_type,
             "hosts": job_backends_hosts,
-            "path":  self.distributed_task_conf.poppy_service_worker_path,
+            "path": self.distributed_task_conf.poppy_service_worker_path,
         }
 
         persistence_backends_hosts = ','.join(['%s:%s' % (

--- a/poppy/distributed_task/taskflow/flow/create_ssl_certificate.py
+++ b/poppy/distributed_task/taskflow/flow/create_ssl_certificate.py
@@ -36,7 +36,7 @@ def create_ssl_certificate():
         linear_flow.Flow("Provision poppy ssl certificate",
                          retry=retry.Times(5)).add(
             create_ssl_certificate_tasks.CreateProviderSSLCertificateTask()
-            ),
+        ),
         create_ssl_certificate_tasks.SendNotificationTask(),
         create_ssl_certificate_tasks.UpdateCertInfoTask()
     )

--- a/poppy/distributed_task/taskflow/flow/delete_ssl_certificate.py
+++ b/poppy/distributed_task/taskflow/flow/delete_ssl_certificate.py
@@ -36,7 +36,7 @@ def delete_ssl_certificate():
         linear_flow.Flow("Deleting poppy ssl certificate",
                          retry=retry.Times(5)).add(
             delete_ssl_certificate_tasks.DeleteProviderSSLCertificateTask()
-            ),
+        ),
         delete_ssl_certificate_tasks.SendNotificationTask(),
         delete_ssl_certificate_tasks.DeleteStorageSSLCertificateTask()
     )

--- a/poppy/distributed_task/taskflow/flow/recreate_ssl_certificate.py
+++ b/poppy/distributed_task/taskflow/flow/recreate_ssl_certificate.py
@@ -38,7 +38,7 @@ def recreate_ssl_certificate():
         linear_flow.Flow("Provision poppy ssl certificate",
                          retry=retry.Times(5)).add(
             create_ssl_certificate_tasks.CreateProviderSSLCertificateTask()
-            ),
+        ),
         create_ssl_certificate_tasks.SendNotificationTask(),
         create_ssl_certificate_tasks.UpdateCertInfoTask()
     )

--- a/poppy/distributed_task/taskflow/task/create_service_tasks.py
+++ b/poppy/distributed_task/taskflow/task/create_service_tasks.py
@@ -75,10 +75,9 @@ class CreateProviderServicesTask(task.Task):
                             project_id=project_id,
                             flavor_id=service_obj.flavor_id,
                             cert_type=domain.certificate
-                            ))
+                        ))
                 except ValueError:
                     domain.cert_info = None
-
 
         responders = []
         # try to create all service from each provider

--- a/poppy/distributed_task/taskflow/task/delete_service_tasks.py
+++ b/poppy/distributed_task/taskflow/task/delete_service_tasks.py
@@ -83,7 +83,7 @@ class DeleteServiceDNSMappingTask(task.Task):
         for provider in provider_details:
             provider_details[provider] = (
                 req_provider_details.load_from_json(provider_details[provider])
-                )
+            )
 
         # delete associated cname records from DNS
         dns_responder = dns.delete(
@@ -171,7 +171,7 @@ class GatherProviderDetailsTask(task.Task):
         for provider in provider_details:
             provider_details[provider] = (
                 req_provider_details.load_from_json(provider_details[provider])
-                )
+            )
 
         for responder in responders:
             provider_name = list(responder.items())[0][0]

--- a/poppy/distributed_task/taskflow/task/delete_ssl_certificate_tasks.py
+++ b/poppy/distributed_task/taskflow/task/delete_ssl_certificate_tasks.py
@@ -25,6 +25,7 @@ LOG = log.getLogger(__name__)
 conf = cfg.CONF
 conf(project='poppy', prog='poppy', args=[])
 
+
 class DeleteProviderSSLCertificateTask(task.Task):
     default_provides = "responders"
 
@@ -38,7 +39,7 @@ class DeleteProviderSSLCertificateTask(task.Task):
             cert_obj = self.storage_controller.get_certs_by_domain(domain_name)
         except ValueError:
             cert_obj = ssl_certificate.SSLCertificate(flavor_id, domain_name,
-                                                  cert_type, project_id)
+                                                      cert_type, project_id)
 
         responders = []
         # try to delete all certificates from each provider
@@ -54,14 +55,15 @@ class DeleteProviderSSLCertificateTask(task.Task):
             if responder:
                 if 'error' in responder[provider]:
                     msg = "Failed to delete ssl certificate: {0} : due to {1}:" \
-                          "The delete operation will be retried".format(
-                        cert_obj.to_dict(), responder[provider]['error'])
+                          "The delete operation will be retried" \
+                        .format(cert_obj.to_dict(), responder[provider]['error'])
                     LOG.info(msg)
                     raise Exception(msg)
 
             responders.append(responder)
 
         return responders
+
 
 class SendNotificationTask(task.Task):
 

--- a/poppy/distributed_task/taskflow/task/update_service_tasks.py
+++ b/poppy/distributed_task/taskflow/task/update_service_tasks.py
@@ -362,8 +362,7 @@ class DeleteCertsForRemovedDomains(task.Task):
         service_old = service.load_from_json(service_old_json)
         old_domains = set([
             domain.domain for domain in service_old.domains
-            if domain.protocol == 'https'
-            and
+            if domain.protocol == 'https' and
             domain.certificate in ['san', 'sni']
         ])
 
@@ -372,8 +371,7 @@ class DeleteCertsForRemovedDomains(task.Task):
         service_new = service.load_from_json(service_new_json)
         new_domains = set([
             domain.domain for domain in service_new.domains
-            if domain.protocol == 'https'
-            and
+            if domain.protocol == 'https' and
             domain.certificate in ['san', 'sni']
         ])
 

--- a/poppy/dns/rackspace/services.py
+++ b/poppy/dns/rackspace/services.py
@@ -190,7 +190,7 @@ class ServicesController(base.ServicesBase):
         else:
             suffix = self._driver.rackdns_conf.url
         # Note: use rindex to find last occurrence of the suffix
-        shard_name = access_url[:access_url.rindex(suffix)-1].split('.')[-1]
+        shard_name = access_url[:access_url.rindex(suffix) - 1].split('.')[-1]
         subdomain_name = '.'.join([shard_name, suffix])
 
         # for sharding is disabled, the suffix is the subdomain_name

--- a/poppy/manager/default/background_job.py
+++ b/poppy/manager/default/background_job.py
@@ -172,11 +172,11 @@ class BackgroundJobController(base.BackgroundJobController):
 
                         try:
                             self.cert_storage.get_certs_by_domain(
-                                    cert_obj.domain_name,
-                                    project_id=cert_obj.project_id,
-                                    flavor_id=cert_obj.flavor_id,
-                                    cert_type=cert_obj.cert_type
-                                )
+                                cert_obj.domain_name,
+                                project_id=cert_obj.project_id,
+                                flavor_id=cert_obj.flavor_id,
+                                cert_type=cert_obj.cert_type
+                            )
                         except ValueError:
                             ignore_list.append(cert_dict)
                             LOG.info(
@@ -336,11 +336,11 @@ class BackgroundJobController(base.BackgroundJobController):
 
                         try:
                             self.cert_storage.get_certs_by_domain(
-                                    cert_obj.domain_name,
-                                    project_id=cert_obj.project_id,
-                                    flavor_id=cert_obj.flavor_id,
-                                    cert_type=cert_obj.cert_type
-                                )
+                                cert_obj.domain_name,
+                                project_id=cert_obj.project_id,
+                                flavor_id=cert_obj.flavor_id,
+                                cert_type=cert_obj.cert_type
+                            )
                         except ValueError:
                             ignore_list.append(cert_dict)
                             LOG.info(

--- a/poppy/manager/default/ssl_certificate.py
+++ b/poppy/manager/default/ssl_certificate.py
@@ -115,7 +115,6 @@ class DefaultSSLCertificateController(base.SSLCertificateController):
             domain_name=domain_name,
             project_id=project_id)
 
-
     def get_san_retry_list(self):
         if 'akamai' in self._driver.providers:
             akamai_driver = self._driver.providers['akamai'].obj
@@ -127,9 +126,9 @@ class DefaultSSLCertificateController(base.SSLCertificateController):
         res = [json.loads(r) for r in res]
         return [
             {"domain_name": r['domain_name'],
-             "project_id":  r['project_id'],
-             "flavor_id":   r['flavor_id'],
-             "cert_type":   r['cert_type'],
+             "project_id": r['project_id'],
+             "flavor_id": r['flavor_id'],
+             "cert_type": r['cert_type'],
              "validate_service": r.get('validate_service', True)}
             for r in res
         ]
@@ -151,16 +150,15 @@ class DefaultSSLCertificateController(base.SSLCertificateController):
                     r['domain_name'])
             except ValueError:
                 LOG.info("No matching certificates found for "
-                "the domain {}".format(r['domain_name']))
+                         "the domain {}".format(r['domain_name']))
 
             if cert_for_domain:
                 if cert_for_domain.get_cert_status() == "deployed":
                     raise ValueError(u'Cert on {0} already exists'.
                                      format(r['domain_name']))
 
-
         new_queue_data = [
-            json.dumps({'flavor_id':   r['flavor_id'],  # flavor_id
+            json.dumps({'flavor_id': r['flavor_id'],  # flavor_id
                         'domain_name': r['domain_name'],    # domain_name
                         'project_id': r['project_id'],
                         'validate_service': r.get('validate_service', True)})

--- a/poppy/provider/akamai/background_jobs/check_cert_status_and_update/check_cert_status_and_update_tasks.py
+++ b/poppy/provider/akamai/background_jobs/check_cert_status_and_update/check_cert_status_and_update_tasks.py
@@ -45,7 +45,6 @@ class GetCertInfoTask(task.Task):
             return ""
 
 
-
 class CheckCertStatusTask(task.Task):
     default_provides = "status_change_to"
 

--- a/poppy/provider/akamai/background_jobs/update_property/update_property_tasks.py
+++ b/poppy/provider/akamai/background_jobs/update_property/update_property_tasks.py
@@ -112,7 +112,7 @@ class PropertyGetLatestVersionTask(task.Task):
                     raise RuntimeError('PAPI API request failed.'
                                        'Exception: %s' % resp.text)
                 LOG.info("New version for : %s is %s" % (self.property_id,
-                                                         str(max_version+1)))
+                                                         str(max_version + 1)))
                 return max_version + 1
 
 

--- a/poppy/provider/akamai/certificates.py
+++ b/poppy/provider/akamai/certificates.py
@@ -127,8 +127,8 @@ class CertificateController(base.CertificateBase):
                     # default san_cert_hostname_limit to the value provided in
                     # the config file.
                     san_cert_hostname_limit = (
-                            san_cert_hostname_limit or
-                            self.driver.san_cert_hostname_limit
+                        san_cert_hostname_limit or
+                        self.driver.san_cert_hostname_limit
                     )
 
                     # Check san_cert to enforce number of hosts hasn't
@@ -402,8 +402,8 @@ class CertificateController(base.CertificateBase):
                         cert_name))
                     continue
                 cert_hostname_limit = (
-                        cert_hostname_limit or
-                        self.driver.san_cert_hostname_limit
+                    cert_hostname_limit or
+                    self.driver.san_cert_hostname_limit
                 )
 
                 host_names_count = utils.get_ssl_number_of_hosts_alternate(
@@ -601,9 +601,7 @@ class CertificateController(base.CertificateBase):
                 if len(resp_json['pendingChanges']) > 0:
                     status = "{0} has pending changes, skipping .." \
                              "{1} delete will be deferred until the" \
-                             "{0} becomes available again".format(
-                        found_cert, cert_obj.domain_name
-                    )
+                             "{0} becomes available again".format(found_cert, cert_obj.domain_name)
                     LOG.info(status)
                     return self.responder.failed(status)
 
@@ -633,9 +631,8 @@ class CertificateController(base.CertificateBase):
                             enrollment_id, resp.text))
                 if resp.status_code != 202:
                     status = "Certificate delete for {0} failed. " \
-                             "Status code {1}. Response {2}.".format(
-                        cert_obj.domain_name, resp.status_code, resp.text
-                    )
+                             "Status code {1}. Response {2}."\
+                        .format(cert_obj.domain_name, resp.status_code, resp.text)
                     LOG.error(status)
                     return self.responder.failed(status)
                 else:
@@ -730,8 +727,7 @@ class CertificateController(base.CertificateBase):
         headers = {
             'Accept': 'application/vnd.akamai.cps.change-id.v1+json'
         }
-        cps_cancel_url = self.driver.akamai_conf.policy_api_base_url + \
-                         change_url[1:]
+        cps_cancel_url = self.driver.akamai_conf.policy_api_base_url + change_url[1:]
         cancel_cps = self.cps_api_client.delete(cps_cancel_url,
                                                 headers=headers)
         if cancel_cps.ok:
@@ -750,4 +746,3 @@ class CertificateController(base.CertificateBase):
                      "again through retry logic".format(change_url)
             LOG.info(status)
             return self.responder.failed(status)
-

--- a/poppy/provider/akamai/geo_zone_code_mapping.py
+++ b/poppy/provider/akamai/geo_zone_code_mapping.py
@@ -20,13 +20,13 @@ from poppy.model.helpers import geo_zones
 LOG = log.getLogger(__name__)
 
 REGIONS = [
-        'North America',
-        'South America',
-        'EMEA',
-        'Japan',
-        'India',
-        'Australia',
-        'APAC']
+    'North America',
+    'South America',
+    'EMEA',
+    'Japan',
+    'India',
+    'Australia',
+    'APAC']
 
 REGION_COUNTRY_MAPPING = {
     'North America': [

--- a/poppy/provider/akamai/services.py
+++ b/poppy/provider/akamai/services.py
@@ -980,8 +980,7 @@ class ServiceController(base.ServiceBase):
                 '%s' %
                 geo_zone_code_mapping.COUNTRY_CODE_MAPPING.get(zone, '')
                 for zone in zones_list
-                if geo_zone_code_mapping.COUNTRY_CODE_MAPPING.get(zone, '')
-                != '']
+                if geo_zone_code_mapping.COUNTRY_CODE_MAPPING.get(zone, '') != '']
             if len(country_code_list) > len(set(country_code_list)):
                 raise ValueError("Duplicated country code in %s" %
                                  str(country_code_list))

--- a/poppy/storage/cassandra/certificates.py
+++ b/poppy/storage/cassandra/certificates.py
@@ -281,7 +281,7 @@ class CertificatesController(base.CertificatesController):
                                      "the domain {}".format(domain_name))
 
             return ssl_cert
-        except:
+        except Exception:
             raise ValueError("No matching certificates found for "
                              "the domain {}".format(domain_name))
 

--- a/poppy/storage/cassandra/services.py
+++ b/poppy/storage/cassandra/services.py
@@ -1028,8 +1028,7 @@ class ServicesController(base.ServicesController):
         domains = [json.loads(d) for d in result.get('domains', []) or []]
         restrictions = [json.loads(r)
                         for r in result.get('restrictions', []) or []]
-        caching_rules = [json.loads(c) for c in result.get('caching_rules', [])
-                         or []]
+        caching_rules = [json.loads(c) for c in result.get('caching_rules', []) or []]
         log_delivery = json.loads(result.get('log_delivery', '{}') or '{}')
         operator_status = result.get('operator_status', 'enabled')
 

--- a/poppy/transport/pecan/controllers/root.py
+++ b/poppy/transport/pecan/controllers/root.py
@@ -36,9 +36,9 @@ class RootController(base.Controller):
         # Remove it from the URL if it's present
         # ['v1.0', 'services'] or ['v1', '123', 'services']
         if (
-            len(args) >= 2
-            and args[0] in self.paths
-            and re.match('^[0-9]+$', args[1])
+                len(args) >= 2 and
+                args[0] in self.paths and
+                re.match('^[0-9]+$', args[1])
         ):
             args.pop(1)
 

--- a/poppy/transport/pecan/controllers/v1/admin.py
+++ b/poppy/transport/pecan/controllers/v1/admin.py
@@ -209,7 +209,7 @@ class AkamaiSanMappingListController(base.Controller, hooks.HookController):
                 self.manager.background_job_controller.
                 put_san_mapping_list(san_mapping_list))
             # queue is the new queue, and deleted is deleted items
-            return {"queue": res,  "deleted": deleted}
+            return {"queue": res, "deleted": deleted}
         except Exception as e:
             pecan.abort(400, str(e))
 
@@ -272,7 +272,7 @@ class AkamaiRetryListController(base.Controller, hooks.HookController):
                 self._driver.manager.ssl_certificate_controller.
                 update_san_retry_list(queue_data))
             # queue is the new queue, and deleted is deleted items
-            return {"queue": res,  "deleted": deleted}
+            return {"queue": res, "deleted": deleted}
         except Exception as e:
             pecan.abort(400, str(e))
 

--- a/poppy/transport/validators/helpers.py
+++ b/poppy/transport/validators/helpers.py
@@ -572,8 +572,7 @@ def is_valid_flavor_id(flavor_id):
 @decorators.validation_function
 def is_valid_analytics_request(request):
     default_end_time = datetime.datetime.utcnow()
-    default_start_time = (datetime.datetime.utcnow()
-                          - datetime.timedelta(days=1))
+    default_start_time = (datetime.datetime.utcnow() - datetime.timedelta(days=1))
     domain = request.GET.get('domain', "")
     startTime = request.GET.get('startTime',
                                 default_start_time.strftime(

--- a/setup.cfg
+++ b/setup.cfg
@@ -85,3 +85,10 @@ universal = 1
 ; method in nose/inspector.py requires a traceback-like object.
 ;
 ; detailed-errors = 1
+
+[flake8]
+exclude = .git,*migrations*
+max-line-length = 119
+; Ignore H202 [assertRaises Exception too broad] warning
+; Ignore E731 [do not assign a lambda expression, use a def]
+ignore = H202,E731

--- a/tests/api/base.py
+++ b/tests/api/base.py
@@ -248,11 +248,10 @@ class TestBase(fixtures.BaseTestFixture):
                                               in expected_response['domains']
                                               if (
                                                   b_item['domain'] ==
-                                                  item['domain'])
-                                              or (b_item.get('certificate') ==
+                                                  item['domain']) or
+                                              (b_item.get('certificate') ==
                                                   'shared' and
-                                                  item['domain'].split('.')[0]
-                                                  == b_item['domain']))
+                                                  item['domain'].split('.')[0] == b_item['domain']))
                 if item['certificate'] == 'shared':
                     matched_domain_in_body['domain'] = item['domain']
                 matched_domain_in_body["certificate_status"] = (

--- a/tests/api/services/test_services.py
+++ b/tests/api/services/test_services.py
@@ -95,8 +95,8 @@ class TestCreateService(providers.TestProviderBase):
                                               in body['domains']
                                               if (
                                                   b_item['domain'] ==
-                                                  item['domain'])
-                                              or (b_item.get('certificate') ==
+                                                  item['domain']) or
+                                              (b_item.get('certificate') ==
                                                   'shared' and
                                                   item['domain'] ==
                                                   b_item['domain']

--- a/tests/unit/distributed_task/taskflow/test_flows.py
+++ b/tests/unit/distributed_task/taskflow/test_flows.py
@@ -221,8 +221,7 @@ class TestFlowRuns(base.TestCase):
         ssl_cert_controller.storage.delete_certificate = mock.Mock()
         storage_controller._driver.close_connection = mock.Mock()
         service_controller.provider_wrapper.delete_certificate = mock.Mock()
-        service_controller.provider_wrapper.delete_certificate. \
-            _mock_return_value = {
+        service_controller.provider_wrapper.delete_certificate._mock_return_value = {
             "cdn_provider": {
                 'error': "",
                 'error_detail': ""

--- a/tests/unit/dns/default/test_services.py
+++ b/tests/unit/dns/default/test_services.py
@@ -54,25 +54,27 @@ class TestServicesCreate(base.TestCase):
 
     def test_create_with_provider_error(self):
 
-        responders = [{
-            'Akamai': {
-                'error': 'Create service failed with Akamai',
-                'error_detail': 'Error details'
-                },
-            'Fastly': {
-                'id': str(uuid.uuid4()),
-                'links': [
+        responders = [
+            {
+                'Akamai':
                     {
-                        'domain': u'blog.mocksite.com',
-                        'href': u'blog.mocksite.com.global.prod.fastly.net',
-                        'rel': 'access_url'
+                        'error': 'Create service failed with Akamai',
+                        'error_detail': 'Error details'
                     },
-                    {
-                        'domain': u'test.mocksite.com',
-                        'href': u'test.mocksite.com.global.prod.fastly.net',
-                        'rel': 'access_url'
-                    }
-                ]}
+                'Fastly': {
+                    'id': str(uuid.uuid4()),
+                    'links': [
+                        {
+                            'domain': u'blog.mocksite.com',
+                            'href': u'blog.mocksite.com.global.prod.fastly.net',
+                            'rel': 'access_url'
+                        },
+                        {
+                            'domain': u'test.mocksite.com',
+                            'href': u'test.mocksite.com.global.prod.fastly.net',
+                            'rel': 'access_url'
+                        }
+                    ]}
             }]
 
         subdomain = mock.Mock()
@@ -86,21 +88,23 @@ class TestServicesCreate(base.TestCase):
 
     def test_create(self):
         domain_names = [u'blog.mocksite.com', u'test.mocksite.com']
-        responders = [{
-            'Fastly': {
-                'id': str(uuid.uuid4()),
-                'links': [
+        responders = [
+            {
+                'Fastly':
                     {
-                        'domain': u'blog.mocksite.com',
-                        'href': u'blog.mocksite.com.global.prod.fastly.net',
-                        'rel': 'access_url'
-                    },
-                    {
-                        'domain': u'test.mocksite.com',
-                        'href': u'test.mocksite.com.global.prod.fastly.net',
-                        'rel': 'access_url'
-                    }
-                ]}
+                        'id': str(uuid.uuid4()),
+                        'links': [
+                            {
+                                'domain': u'blog.mocksite.com',
+                                'href': u'blog.mocksite.com.global.prod.fastly.net',
+                                'rel': 'access_url'
+                            },
+                            {
+                                'domain': u'test.mocksite.com',
+                                'href': u'test.mocksite.com.global.prod.fastly.net',
+                                'rel': 'access_url'
+                            }
+                        ]}
             }]
 
         subdomain = mock.Mock()
@@ -213,11 +217,13 @@ class TestServicesUpdate(base.TestCase):
             origins=[],
             flavor_id='standard')
 
-        responders = [{
-            'Fastly': {
-                'id': str(uuid.uuid4()),
-                'error': 'Create service failed'
-                }
+        responders = [
+            {
+                'Fastly':
+                    {
+                        'id': str(uuid.uuid4()),
+                        'error': 'Create service failed'
+                    }
             }]
 
         dns_details = self.controller.update(self.service_old,
@@ -236,16 +242,19 @@ class TestServicesUpdate(base.TestCase):
             origins=[],
             flavor_id='standard')
 
-        responders = [{
-            'Fastly': {
-                'id': str(uuid.uuid4()),
-                'links': [
+        responders = [
+            {
+                'Fastly':
                     {
-                        'domain': u'test.domain.com',
-                        'href': u'test.domain.com.global.prod.fastly.net',
-                        'rel': 'access_url'
+                        'id': str(uuid.uuid4()),
+                        'links': [
+                            {
+                                'domain': u'test.domain.com',
+                                'href': u'test.domain.com.global.prod.fastly.net',
+                                'rel': 'access_url'
+                            }
+                        ]
                     }
-                ]}
             }]
 
         dns_details = self.controller.update(self.service_old,
@@ -273,21 +282,24 @@ class TestServicesUpdate(base.TestCase):
             origins=[],
             flavor_id='standard')
 
-        responders = [{
-            'Fastly': {
-                'id': str(uuid.uuid4()),
-                'links': [
+        responders = [
+            {
+                'Fastly':
                     {
-                        'domain': u'blog.domain.com',
-                        'href': u'blog.domain.com.global.prod.fastly.net',
-                        'rel': 'access_url'
-                    },
-                    {
-                        'domain': u'test.domain.com',
-                        'href': u'test.domain.com.global.prod.fastly.net',
-                        'rel': 'access_url'
+                        'id': str(uuid.uuid4()),
+                        'links': [
+                            {
+                                'domain': u'blog.domain.com',
+                                'href': u'blog.domain.com.global.prod.fastly.net',
+                                'rel': 'access_url'
+                            },
+                            {
+                                'domain': u'test.domain.com',
+                                'href': u'test.domain.com.global.prod.fastly.net',
+                                'rel': 'access_url'
+                            }
+                        ]
                     }
-                ]}
             }]
 
         dns_details = self.controller.update(self.service_old,
@@ -322,26 +334,29 @@ class TestServicesUpdate(base.TestCase):
             origins=[],
             flavor_id='standard')
 
-        responders = [{
-            'Fastly': {
-                'id': str(uuid.uuid4()),
-                'links': [
+        responders = [
+            {
+                'Fastly':
                     {
-                        'domain': u'test.domain.com',
-                        'href': u'test.domain.com.global.prod.fastly.net',
-                        'rel': 'access_url'
-                    },
-                    {
-                        'domain': u'blog.domain.com',
-                        'href': u'blog.domain.com.global.prod.fastly.net',
-                        'rel': 'access_url'
-                    },
-                    {
-                        'domain': u'pictures.domain.com',
-                        'href': u'pictures.domain.com.global.prod.fastly.net',
-                        'rel': 'access_url'
+                        'id': str(uuid.uuid4()),
+                        'links': [
+                            {
+                                'domain': u'test.domain.com',
+                                'href': u'test.domain.com.global.prod.fastly.net',
+                                'rel': 'access_url'
+                            },
+                            {
+                                'domain': u'blog.domain.com',
+                                'href': u'blog.domain.com.global.prod.fastly.net',
+                                'rel': 'access_url'
+                            },
+                            {
+                                'domain': u'pictures.domain.com',
+                                'href': u'pictures.domain.com.global.prod.fastly.net',
+                                'rel': 'access_url'
+                            }
+                        ]
                     }
-                ]}
             }]
 
         dns_details = self.controller.update(

--- a/tests/unit/dns/rackspace/test_services.py
+++ b/tests/unit/dns/rackspace/test_services.py
@@ -105,25 +105,27 @@ class TestServicesCreate(base.TestCase):
 
     def test_create_with_provider_error(self):
 
-        responders = [{
-            'Akamai': {
-                'error': 'Create service failed with Akamai',
-                'error_detail': 'Error details'
-                },
-            'Fastly': {
-                'id': str(uuid.uuid4()),
-                'links': [
+        responders = [
+            {
+                'Akamai':
                     {
-                        'domain': u'blog.mocksite.com',
-                        'href': u'blog.mocksite.com.global.prod.fastly.net',
-                        'rel': 'access_url'
+                        'error': 'Create service failed with Akamai',
+                        'error_detail': 'Error details'
                     },
-                    {
-                        'domain': u'test.mocksite.com',
-                        'href': u'test.mocksite.com.global.prod.fastly.net',
-                        'rel': 'access_url'
-                    }
-                ]}
+                'Fastly': {
+                    'id': str(uuid.uuid4()),
+                    'links': [
+                        {
+                            'domain': u'blog.mocksite.com',
+                            'href': u'blog.mocksite.com.global.prod.fastly.net',
+                            'rel': 'access_url'
+                        },
+                        {
+                            'domain': u'test.mocksite.com',
+                            'href': u'test.mocksite.com.global.prod.fastly.net',
+                            'rel': 'access_url'
+                        }
+                    ]}
             }]
 
         subdomain = mock.Mock()
@@ -139,21 +141,22 @@ class TestServicesCreate(base.TestCase):
 
     def test_create_with_subdomain_not_found_exception(self):
         domain_names = [u'blog.mocksite.com', u'test.mocksite.com']
-        responders = [{
-            'Fastly': {
-                'id': str(uuid.uuid4()),
-                'links': [
-                    {
-                        'domain': u'blog.mocksite.com',
-                        'href': u'blog.mocksite.com.global.prod.fastly.net',
-                        'rel': 'access_url'
-                    },
-                    {
-                        'domain': u'test.mocksite.com',
-                        'href': u'test.mocksite.com.global.prod.fastly.net',
-                        'rel': 'access_url'
-                    }
-                ]}
+        responders = [
+            {
+                'Fastly': {
+                    'id': str(uuid.uuid4()),
+                    'links': [
+                        {
+                            'domain': u'blog.mocksite.com',
+                            'href': u'blog.mocksite.com.global.prod.fastly.net',
+                            'rel': 'access_url'
+                        },
+                        {
+                            'domain': u'test.mocksite.com',
+                            'href': u'test.mocksite.com.global.prod.fastly.net',
+                            'rel': 'access_url'
+                        }
+                    ]}
             }]
 
         self.client.find = mock.Mock(
@@ -175,21 +178,22 @@ class TestServicesCreate(base.TestCase):
                         access_urls_map[provider_name][domain_name])
 
     def test_create_with_generic_exception(self):
-        responders = [{
-            'Fastly': {
-                'id': str(uuid.uuid4()),
-                'links': [
-                    {
-                        'domain': u'blog.mocksite.com',
-                        'href': u'blog.mocksite.com.global.prod.fastly.net',
-                        'rel': 'access_url'
-                    },
-                    {
-                        'domain': u'test.mocksite.com',
-                        'href': u'test.mocksite.com.global.prod.fastly.net',
-                        'rel': 'access_url'
-                    }
-                ]}
+        responders = [
+            {
+                'Fastly': {
+                    'id': str(uuid.uuid4()),
+                    'links': [
+                        {
+                            'domain': u'blog.mocksite.com',
+                            'href': u'blog.mocksite.com.global.prod.fastly.net',
+                            'rel': 'access_url'
+                        },
+                        {
+                            'domain': u'test.mocksite.com',
+                            'href': u'test.mocksite.com.global.prod.fastly.net',
+                            'rel': 'access_url'
+                        }
+                    ]}
             }]
 
         subdomain = mock.Mock()
@@ -206,31 +210,32 @@ class TestServicesCreate(base.TestCase):
 
     def test_create(self):
         domain_names = [u'blog.mocksite.com', u'test.mocksite.com']
-        responders = [{
-            'Fastly': {
-                'id': str(uuid.uuid4()),
-                'links': [
-                    {
-                        'domain': u'blog.mocksite.com',
-                        'href': u'blog.mocksite.com.global.prod.fastly.net',
-                        'rel': 'access_url'
-                    },
-                    {
-                        'domain': u'test.mocksite.com',
-                        'href': u'test.mocksite.com.global.prod.fastly.net',
-                        'rel': 'access_url'
-                    },
-                    {
-                        'href': 'https://cloudfiles.rackspace/CONTAINER/OBJ',
-                        'rel': 'log_delivery'
-                    },
-                    {
-                        'domain': u'shared.mocksite.com',
-                        'href': u'test.mocksite.com.global.prod.fastly.net',
-                        'certificate': 'shared',
-                        'rel': 'access_url'
-                    },
-                ]}
+        responders = [
+            {
+                'Fastly': {
+                    'id': str(uuid.uuid4()),
+                    'links': [
+                        {
+                            'domain': u'blog.mocksite.com',
+                            'href': u'blog.mocksite.com.global.prod.fastly.net',
+                            'rel': 'access_url'
+                        },
+                        {
+                            'domain': u'test.mocksite.com',
+                            'href': u'test.mocksite.com.global.prod.fastly.net',
+                            'rel': 'access_url'
+                        },
+                        {
+                            'href': 'https://cloudfiles.rackspace/CONTAINER/OBJ',
+                            'rel': 'log_delivery'
+                        },
+                        {
+                            'domain': u'shared.mocksite.com',
+                            'href': u'test.mocksite.com.global.prod.fastly.net',
+                            'certificate': 'shared',
+                            'rel': 'access_url'
+                        },
+                    ]}
             }]
 
         subdomain = mock.Mock()
@@ -604,26 +609,27 @@ class TestServicesUpdate(base.TestCase):
             origins=[],
             flavor_id='standard')
 
-        responders = [{
-            'Fastly': {
-                'id': str(uuid.uuid4()),
-                'links': [
-                    {
-                        'domain': u'test.domain.com',
-                        'href': u'test.domain.com.global.prod.fastly.net',
-                        'rel': 'access_url'
-                    },
-                    {
-                        'domain': u'blog.domain.com',
-                        'href': u'blog.domain.com.global.prod.fastly.net',
-                        'rel': 'access_url'
-                    },
-                    {
-                        'domain': u'pictures.domain.com',
-                        'href': u'pictures.domain.com.global.prod.fastly.net',
-                        'rel': 'access_url'
-                    }
-                ]}
+        responders = [
+            {
+                'Fastly': {
+                    'id': str(uuid.uuid4()),
+                    'links': [
+                        {
+                            'domain': u'test.domain.com',
+                            'href': u'test.domain.com.global.prod.fastly.net',
+                            'rel': 'access_url'
+                        },
+                        {
+                            'domain': u'blog.domain.com',
+                            'href': u'blog.domain.com.global.prod.fastly.net',
+                            'rel': 'access_url'
+                        },
+                        {
+                            'domain': u'pictures.domain.com',
+                            'href': u'pictures.domain.com.global.prod.fastly.net',
+                            'rel': 'access_url'
+                        }
+                    ]}
             }]
 
         dns_details = self.controller.update(self.service_old,
@@ -652,26 +658,27 @@ class TestServicesUpdate(base.TestCase):
             flavor_id='standard'
         )
 
-        responders = [{
-            'Fastly': {
-                'id': str(uuid.uuid4()),
-                'links': [
-                    {
-                        'domain': u'test.domain.com',
-                        'href': u'test.domain.com.global.prod.fastly.net',
-                        'rel': 'access_url'
-                    },
-                    {
-                        'domain': u'blog.domain.com',
-                        'href': u'blog.domain.com.global.prod.fastly.net',
-                        'rel': 'access_url'
-                    },
-                    {
-                        'domain': u'pictures.domain.com',
-                        'href': u'pictures.domain.com.global.prod.fastly.net',
-                        'rel': 'access_url'
-                    }
-                ]}
+        responders = [
+            {
+                'Fastly': {
+                    'id': str(uuid.uuid4()),
+                    'links': [
+                        {
+                            'domain': u'test.domain.com',
+                            'href': u'test.domain.com.global.prod.fastly.net',
+                            'rel': 'access_url'
+                        },
+                        {
+                            'domain': u'blog.domain.com',
+                            'href': u'blog.domain.com.global.prod.fastly.net',
+                            'rel': 'access_url'
+                        },
+                        {
+                            'domain': u'pictures.domain.com',
+                            'href': u'pictures.domain.com.global.prod.fastly.net',
+                            'rel': 'access_url'
+                        }
+                    ]}
             }]
 
         dns_details = self.controller.update(
@@ -699,11 +706,13 @@ class TestServicesUpdate(base.TestCase):
             origins=[],
             flavor_id='standard')
 
-        responders = [{
-            'Fastly': {
-                'id': str(uuid.uuid4()),
-                'error': 'Create service failed'
-                }
+        responders = [
+            {
+                'Fastly':
+                    {
+                        'id': str(uuid.uuid4()),
+                        'error': 'Create service failed'
+                    }
             }]
 
         dns_details = self.controller.update(self.service_old,
@@ -743,21 +752,22 @@ class TestServicesUpdate(base.TestCase):
             origins=[],
             flavor_id='standard')
 
-        responders = [{
-            'Fastly': {
-                'id': str(uuid.uuid4()),
-                'links': [
-                    {
-                        'domain': u'blog.domain.com',
-                        'href': u'blog.domain.com.global.prod.fastly.net',
-                        'rel': 'access_url'
-                    },
-                    {
-                        'domain': u'test.domain.com',
-                        'href': u'test.domain.com.global.prod.fastly.net',
-                        'rel': 'access_url'
-                    }
-                ]}
+        responders = [
+            {
+                'Fastly': {
+                    'id': str(uuid.uuid4()),
+                    'links': [
+                        {
+                            'domain': u'blog.domain.com',
+                            'href': u'blog.domain.com.global.prod.fastly.net',
+                            'rel': 'access_url'
+                        },
+                        {
+                            'domain': u'test.domain.com',
+                            'href': u'test.domain.com.global.prod.fastly.net',
+                            'rel': 'access_url'
+                        }
+                    ]}
             }]
 
         dns_details = self.controller.update(self.service_old,
@@ -787,16 +797,17 @@ class TestServicesUpdate(base.TestCase):
             origins=[],
             flavor_id='standard')
 
-        responders = [{
-            'Fastly': {
-                'id': str(uuid.uuid4()),
-                'links': [
-                    {
-                        'domain': u'test.domain.com',
-                        'href': u'test.domain.com.global.prod.fastly.net',
-                        'rel': 'access_url'
-                    }
-                ]}
+        responders = [
+            {
+                'Fastly': {
+                    'id': str(uuid.uuid4()),
+                    'links': [
+                        {
+                            'domain': u'test.domain.com',
+                            'href': u'test.domain.com.global.prod.fastly.net',
+                            'rel': 'access_url'
+                        }
+                    ]}
             }]
 
         dns_details = self.controller.update(self.service_old,
@@ -824,21 +835,22 @@ class TestServicesUpdate(base.TestCase):
             origins=[],
             flavor_id='standard')
 
-        responders = [{
-            'Fastly': {
-                'id': str(uuid.uuid4()),
-                'links': [
-                    {
-                        'domain': u'blog.domain.com',
-                        'href': u'blog.domain.com.global.prod.fastly.net',
-                        'rel': 'access_url'
-                    },
-                    {
-                        'domain': u'test.domain.com',
-                        'href': u'test.domain.com.global.prod.fastly.net',
-                        'rel': 'access_url'
-                    }
-                ]}
+        responders = [
+            {
+                'Fastly': {
+                    'id': str(uuid.uuid4()),
+                    'links': [
+                        {
+                            'domain': u'blog.domain.com',
+                            'href': u'blog.domain.com.global.prod.fastly.net',
+                            'rel': 'access_url'
+                        },
+                        {
+                            'domain': u'test.domain.com',
+                            'href': u'test.domain.com.global.prod.fastly.net',
+                            'rel': 'access_url'
+                        }
+                    ]}
             }]
 
         dns_details = self.controller.update(self.service_old,
@@ -875,28 +887,29 @@ class TestServicesUpdate(base.TestCase):
             origins=[],
             flavor_id='standard')
 
-        responders = [{
-            'Fastly': {
-                'id': str(uuid.uuid4()),
-                'links': [
-                    {
-                        'domain': u'test.domain.com',
-                        'href': u'test.domain.com.global.prod.fastly.net',
-                        'rel': 'access_url'
-                    },
-                    {
-                        'domain': u'blog.domain.com',
-                        'href': u'blog.domain.com.global.prod.fastly.net',
-                        'rel': 'access_url'
-                    },
-                    {
-                        'domain': u'pictures.domain.com',
-                        'href': u'pictures.domain.com.global.prod.fastly.net',
-                        'rel': 'access_url',
-                        'certificate': 'san',
-                        'old_operator_url': 'old.operator.url.cdn99.mycdn.com'
-                    }
-                ]}
+        responders = [
+            {
+                'Fastly': {
+                    'id': str(uuid.uuid4()),
+                    'links': [
+                        {
+                            'domain': u'test.domain.com',
+                            'href': u'test.domain.com.global.prod.fastly.net',
+                            'rel': 'access_url'
+                        },
+                        {
+                            'domain': u'blog.domain.com',
+                            'href': u'blog.domain.com.global.prod.fastly.net',
+                            'rel': 'access_url'
+                        },
+                        {
+                            'domain': u'pictures.domain.com',
+                            'href': u'pictures.domain.com.global.prod.fastly.net',
+                            'rel': 'access_url',
+                            'certificate': 'san',
+                            'old_operator_url': 'old.operator.url.cdn99.mycdn.com'
+                        }
+                    ]}
             }]
 
         dns_details = self.controller.update(self.service_old,
@@ -934,23 +947,24 @@ class TestServicesUpdate(base.TestCase):
             origins=[],
             flavor_id='standard')
 
-        responders = [{
-            'Fastly': {
-                'id': str(uuid.uuid4()),
-                'links': [
-                    {
-                        'domain': u'test.domain.com',
-                        'href': u'test.domain.com.global.prod.fastly.net',
-                        'rel': 'access_url'
-                    },
-                    {
-                        'domain': u'blog.domain.com',
-                        'href': u'blog.domain.com.global.prod.fastly.net',
-                        'rel': 'access_url',
-                        'certificate': 'san',
-                        'old_operator_url': 'old.operator.url.cdn99.mycdn.com'
-                    }
-                ]}
+        responders = [
+            {
+                'Fastly': {
+                    'id': str(uuid.uuid4()),
+                    'links': [
+                        {
+                            'domain': u'test.domain.com',
+                            'href': u'test.domain.com.global.prod.fastly.net',
+                            'rel': 'access_url'
+                        },
+                        {
+                            'domain': u'blog.domain.com',
+                            'href': u'blog.domain.com.global.prod.fastly.net',
+                            'rel': 'access_url',
+                            'certificate': 'san',
+                            'old_operator_url': 'old.operator.url.cdn99.mycdn.com'
+                        }
+                    ]}
             }]
 
         dns_details = self.controller.update(
@@ -993,23 +1007,24 @@ class TestServicesUpdate(base.TestCase):
             origins=[],
             flavor_id='standard')
 
-        responders = [{
-            'Fastly': {
-                'id': str(uuid.uuid4()),
-                'links': [
-                    {
-                        'domain': u'test.domain.com',
-                        'href': u'test.domain.com.global.prod.fastly.net',
-                        'rel': 'access_url'
-                    },
-                    {
-                        'domain': u'blog.domain.com',
-                        'href': u'blog.domain.com.global.prod.fastly.net',
-                        'rel': 'access_url',
-                        'certificate': 'san',
-                        'old_operator_url': 'old.operator.url.cdn99.mycdn.com'
-                    }
-                ]}
+        responders = [
+            {
+                'Fastly': {
+                    'id': str(uuid.uuid4()),
+                    'links': [
+                        {
+                            'domain': u'test.domain.com',
+                            'href': u'test.domain.com.global.prod.fastly.net',
+                            'rel': 'access_url'
+                        },
+                        {
+                            'domain': u'blog.domain.com',
+                            'href': u'blog.domain.com.global.prod.fastly.net',
+                            'rel': 'access_url',
+                            'certificate': 'san',
+                            'old_operator_url': 'old.operator.url.cdn99.mycdn.com'
+                        }
+                    ]}
             }]
 
         dns_details = self.controller.update(
@@ -1043,23 +1058,24 @@ class TestServicesUpdate(base.TestCase):
             origins=[],
             flavor_id='standard')
 
-        responders = [{
-            'Fastly': {
-                'id': str(uuid.uuid4()),
-                'links': [
-                    {
-                        'domain': u'test.domain.com',
-                        'href': u'test.domain.com.global.prod.fastly.net',
-                        'rel': 'access_url'
-                    },
-                    {
-                        'domain': u'blog.domain.com',
-                        'href': u'blog.domain.com.global.prod.fastly.net',
-                        'rel': 'access_url',
-                        'certificate': 'san',
-                        'old_operator_url': 'old.operator.url.cdn99.mycdn.com'
-                    }
-                ]}
+        responders = [
+            {
+                'Fastly': {
+                    'id': str(uuid.uuid4()),
+                    'links': [
+                        {
+                            'domain': u'test.domain.com',
+                            'href': u'test.domain.com.global.prod.fastly.net',
+                            'rel': 'access_url'
+                        },
+                        {
+                            'domain': u'blog.domain.com',
+                            'href': u'blog.domain.com.global.prod.fastly.net',
+                            'rel': 'access_url',
+                            'certificate': 'san',
+                            'old_operator_url': 'old.operator.url.cdn99.mycdn.com'
+                        }
+                    ]}
             }]
 
         dns_details = self.controller.update(
@@ -1100,26 +1116,27 @@ class TestServicesUpdate(base.TestCase):
             log_delivery=log_delivery.LogDelivery(enabled=True)
         )
         self.service_old.log_delivery = log_delivery.LogDelivery(enabled=True)
-        responders = [{
-            'Fastly': {
-                'id': str(uuid.uuid4()),
-                'links': [
-                    {
-                        'domain': u'test.domain.com',
-                        'href': u'test.domain.com.global.prod.fastly.net',
-                        'rel': 'access_url'
-                    },
-                    {
-                        'domain': u'blog.domain.com',
-                        'href': u'blog.domain.com.global.prod.fastly.net',
-                        'rel': 'access_url'
-                    },
-                    {
-                        'domain': u'pictures.domain.com',
-                        'href': u'pictures.domain.com.global.prod.fastly.net',
-                        'rel': 'access_url'
-                    }
-                ]}
+        responders = [
+            {
+                'Fastly': {
+                    'id': str(uuid.uuid4()),
+                    'links': [
+                        {
+                            'domain': u'test.domain.com',
+                            'href': u'test.domain.com.global.prod.fastly.net',
+                            'rel': 'access_url'
+                        },
+                        {
+                            'domain': u'blog.domain.com',
+                            'href': u'blog.domain.com.global.prod.fastly.net',
+                            'rel': 'access_url'
+                        },
+                        {
+                            'domain': u'pictures.domain.com',
+                            'href': u'pictures.domain.com.global.prod.fastly.net',
+                            'rel': 'access_url'
+                        }
+                    ]}
             }]
 
         dns_details = self.controller.update(self.service_old,

--- a/tests/unit/manager/default/test_services.py
+++ b/tests/unit/manager/default/test_services.py
@@ -641,9 +641,9 @@ class DefaultManagerServiceTests(base.TestCase):
                             }
                         ]
                     }
-                    ]
-                }
+                ]
             }
+        }
         with MonkeyPatchControllers(self.sc,
                                     self.sc.dns_controller,
                                     self.sc.storage_controller,

--- a/tests/unit/model/helpers/test_provider_details.py
+++ b/tests/unit/model/helpers/test_provider_details.py
@@ -68,5 +68,4 @@ class TestProviderDetails(base.TestCase):
 
         self.assertTrue(
             self.my_provider_detail.domains_certificate_status.
-            get_domain_certificate_status("www.ab.com")
-            == status)
+            get_domain_certificate_status("www.ab.com") == status)

--- a/tests/unit/provider/akamai/background_jobs/akamai_mocks.py
+++ b/tests/unit/provider/akamai/background_jobs/akamai_mocks.py
@@ -114,15 +114,16 @@ class MockStorageController(mock.Mock):
             "san",
             project_id=project_id,
             cert_details={
-                'Akamai': {
-                    u'cert_domain': u'secure2.san1.test_123.com',
-                    u'extra_info': {
-                        u'action': u'Waiting for customer domain '
-                                    'validation for blog.testabc.com',
-                        u'akamai_spsId': str(random.randint(1, 100000)),
-                        u'create_at': u'2015-09-29 16:09:12.429147',
-                        u'san cert': u'secure2.san1.test_123.com',
-                        u'status': u'create_in_progress'}
+                'Akamai':
+                    {
+                        u'cert_domain': u'secure2.san1.test_123.com',
+                        u'extra_info': {
+                            u'action': u'Waiting for customer domain '
+                                        'validation for blog.testabc.com',
+                            u'akamai_spsId': str(random.randint(1, 100000)),
+                            u'create_at': u'2015-09-29 16:09:12.429147',
+                            u'san cert': u'secure2.san1.test_123.com',
+                            u'status': u'create_in_progress'}
                     }
             }
         )
@@ -271,7 +272,7 @@ class MockPapiAPIClient(mock.Mock):
                         "edgeHostnameId": "ehn_1126816",
                         "cnameFrom": "secure.san2.test_789.com",
                         "cnameTo": "secure.test_456.com.edge_host_test.net"
-                    },  {
+                    }, {
                         'cnameTo': 'secure.test_7891.com.edge_host_test.net',
                         'cnameFrom': 'www.blogyyy.com',
                         'edgeHostnameId': 'ehn_1126816',
@@ -297,10 +298,12 @@ class MockSPSAPIClient(mock.Mock):
             "requestList":
                 [{"resourceUrl": "/config-secure-provisioning-service/"
                                  "v1/sps-requests/1849",
-                    "parameters": [{
-                        "name": "cnameHostname",
-                        "value": "secure.san3.test_123.com"
-                        }, {"name": "createType", "value": "san"},
+                    "parameters": [
+                        {
+                            "name": "cnameHostname",
+                            "value": "secure.san3.test_123.com"
+                        },
+                        {"name": "createType", "value": "san"},
                         {"name": "csr.cn",
                          "value": "secure.san3.test_123.com"},
                         {"name": "csr.c", "value": "US"},

--- a/tests/unit/provider/akamai/cert_info_storage/test_cassandra_cert_info_storage.py
+++ b/tests/unit/provider/akamai/cert_info_storage/test_cassandra_cert_info_storage.py
@@ -190,7 +190,7 @@ class TestCassandraCertInfoStorage(base.TestCase):
         self.assertTrue(
             res['spsId'] == str(json.loads(
                 self.get_returned_value[0]['info']['san_info']
-                )[cert_name]['spsId'])
+            )[cert_name]['spsId'])
         )
 
     def test_get_sni_cert_info(self):
@@ -207,7 +207,7 @@ class TestCassandraCertInfoStorage(base.TestCase):
         self.assertTrue(
             res['enrollmentId'] == str(json.loads(
                 self.get_returned_value[0]['info']['sni_info']
-                )[cert_name]['enrollmentId'])
+            )[cert_name]['enrollmentId'])
         )
 
     def test_update_cert_config(self):

--- a/tests/unit/provider/akamai/test_certificates.py
+++ b/tests/unit/provider/akamai/test_certificates.py
@@ -1071,15 +1071,12 @@ class TestCertificates(base.TestCase):
 
         status = "{0} has pending changes, skipping .." \
                  "{1} delete will be deferred until the" \
-                 "{0} becomes available again".format(
-            "0", cert_obj.domain_name
-        )
+                 "{0} becomes available again".format("0", cert_obj.domain_name)
 
         self.assertEqual(
             status,
             responder['Akamai']['error']
         )
-
 
     def test_cert_delete_sni_cert_positive(self):
 

--- a/tests/unit/provider/akamai/test_services.py
+++ b/tests/unit/provider/akamai/test_services.py
@@ -754,8 +754,7 @@ class TestServices(base.TestCase):
         )
         purge_url = '/img/abc.jpeg'
         actual_purge_url = ("https://" +
-                            json.loads(provider_service_id)[0]['policy_name']
-                            + purge_url)
+                            json.loads(provider_service_id)[0]['policy_name'] + purge_url)
         data = {
             'objects': [
                 actual_purge_url

--- a/tests/unit/storage/cassandra/test_certificates.py
+++ b/tests/unit/storage/cassandra/test_certificates.py
@@ -128,7 +128,7 @@ class CassandraStorageCertificateTests(base.TestCase):
         Should receive an Exception.
         """
         self.cc.get_certs_by_domain(
-                             domain_name="www.randomdomain.com")
+            domain_name="www.randomdomain.com")
 
     def test_get_certs_by_status(self):
         # mock the response from cassandra

--- a/tools/colorizer.py
+++ b/tools/colorizer.py
@@ -107,15 +107,16 @@ class _Win32Colorizer(object):
         self.stream = stream
         self.screenBuffer = win32console.GetStdHandle(
             win32console.STD_OUT_HANDLE)
-        self._colors = {
-            'normal': red | green | blue,
-            'red': red | bold,
-            'green': green | bold,
-            'blue': blue | bold,
-            'yellow': red | green | bold,
-            'magenta': red | blue | bold,
-            'cyan': green | blue | bold,
-            'white': red | green | blue | bold
+        self._colors = \
+            {
+                'normal': red | green | blue,
+                'red': red | bold,
+                'green': green | bold,
+                'blue': blue | bold,
+                'yellow': red | green | bold,
+                'magenta': red | blue | bold,
+                'cyan': green | blue | bold,
+                'white': red | green | blue | bold
             }
 
     def supported(cls, stream=sys.stdout):


### PR DESCRIPTION
Correct existing code to reflect PEP-8 standards so that
Flake8 tests will pass.

Setting max_line_length property of PEP-8 to 119 from default 79.