### PR TITLE
[CDN-1251] Modify retry_list API to support cert_type.

### DIFF
--- a/poppy/manager/default/ssl_certificate.py
+++ b/poppy/manager/default/ssl_certificate.py
@@ -160,9 +160,10 @@ class DefaultSSLCertificateController(base.SSLCertificateController):
 
 
         new_queue_data = [
-            json.dumps({'flavor_id':   r['flavor_id'],  # flavor_id
-                        'domain_name': r['domain_name'],    # domain_name
+            json.dumps({'flavor_id':   r['flavor_id'],
+                        'domain_name': r['domain_name'],
                         'project_id': r['project_id'],
+                        'cert_type': r['cert_type'],
                         'validate_service': r.get('validate_service', True)})
             for r in queue_data_list
         ]

--- a/poppy/transport/validators/schemas/ssl_certificate.py
+++ b/poppy/transport/validators/schemas/ssl_certificate.py
@@ -80,6 +80,11 @@ class SSLCertificateSchema(schema_base.SchemaBase):
                                                   '{1,256})$'),
                             'required': True,
                         },
+                        'cert_type': {
+                            'type': 'string',
+                            'required': True,
+                            'enum': ['san', 'sni'],
+                        },
                         'validate_service': {
                             'type': 'boolean'
                         }

--- a/tests/functional/transport/pecan/controllers/test_retry_list.py
+++ b/tests/functional/transport/pecan/controllers/test_retry_list.py
@@ -56,12 +56,14 @@ class TestRetryList(base.FunctionalTest):
                 "domain_name": "test-san1.cnamecdn.com",
                 "project_id": "000",
                 "flavor_id": "premium",
+                "cert_type": "sni",
                 "validate_service": False
             },
             {
                 "domain_name": "test-san2.cnamecdn.com",
                 "project_id": "000",
                 "flavor_id": "premium",
+                "cert_type": "sni",
                 "validate_service": False
             }
         ]
@@ -234,12 +236,14 @@ class TestRetryList(base.FunctionalTest):
                 "domain_name": "test-san1.cnamecdn.com",
                 "project_id": "000",
                 "flavor_id": "premium",
+                "cert_type": "sni",
                 "validate_service": False
             },
             {
                 "domain_name": "test-san2.cnamecdn.com",
                 "project_id": self.project_id,
                 "flavor_id": "premium",
+                "cert_type": "sni",
                 "validate_service": True
             }
         ]

--- a/tests/unit/manager/default/test_ssl_certificate.py
+++ b/tests/unit/manager/default/test_ssl_certificate.py
@@ -250,6 +250,7 @@ class DefaultSSLCertificateControllerTests(base.TestCase):
             "domain_name": "a_domain",
             "project_id": "00000",
             "flavor_id": "flavor",
+            "cert_type": "sni",
             "validate_service": True
         }]
 
@@ -266,6 +267,7 @@ class DefaultSSLCertificateControllerTests(base.TestCase):
                 "domain_name": "b_domain",
                 "project_id": "00000",
                 "flavor_id": "flavor",
+                "cert_type": "sni",
                 "validate_service": True
             }
         ]


### PR DESCRIPTION
Currently the GET and PUT APIs of `retry_list` does not support the
parameter `cert_type` from the request payload.

This is an issue which can be observed by manually the calling these
APIs and supplying the `cert_type` parameter in the request payload
for PUT. The same issue is observed for GET request as well when
the backend programatically had `cert_type` in the retry queue but
GET will fail to fetch these details.

Modifying both GET and PUT requests to enable the support for
`cert_type` parameter.