### PR TITLE
Pin release version to 2019.3.7

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -71,26 +71,14 @@ pipeline {
                 }
             }
         }
-        stage('PyPI Preview') {
+        stage('Upload Wheel') {
             when { anyOf { branch 'pre-release'; branch 'release' } }
             steps {
                 sh '''
                 echo "Build and Upload PREVIEW Wheel for $BRANCH_NAME"
                 . poppy_venv/bin/activate
                 rm -rf dist
-                PBR_VERSION=2019.3.${BUILD_NUMBER} python setup.py bdist_wheel upload -v -r prev
-                '''
-            }
-        }
-        stage('PyPI Production') {
-            when { branch 'release' }
-            steps {
-                echo "want to use when tag regex here but it seems broken, using when branch for now"
-                sh '''
-                echo "Build and Upload PROD Wheel for $TAG_NAME - this is temporarily disabled"
-                . poppy_venv/bin/activate
-                rm -rf dist
-                PBR_VERSION=2019.3.${BUILD_NUMBER} python setup.py bdist_wheel upload -v -r prod
+                PBR_VERSION=2019.3.7 python setup.py bdist_wheel upload -v -r prev
                 '''
             }
         }


### PR DESCRIPTION
 - Pin to 2019.3.7 to match what is currently in prod
 - Remove redundant pyshop prod path as it is not setup nor needed